### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@loop-crypto/loop-core-sdk",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Loop Core SDK",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
# 🌞 Tasks completed
<!-- Required tasks completed that the reviewer can "check" when confirmed -->

1. [ ] Bumped the version number after publishing a new version

# 📑 Notes for reviewer
<!-- Anything worth noting for the reviewer (or for posterity) -->

- The existing published version (`v0.1.1`) was broken - the route endpoints were inconsistent (some had `/v2/...`, some didn't) even though the code was correct. So something must have been bad with the codebase where it was published from

