### PR TITLE
LC-3739: Updated payment methods endpoints

### DIFF
--- a/__tests__/unit/paymentMethod.test.ts
+++ b/__tests__/unit/paymentMethod.test.ts
@@ -60,7 +60,7 @@ describe("PaymentMethod API", () => {
         requestMock.mockResolvedValue(mockResponse);
         const response = await paymentMethodApi.search(queryParams);
         expect(requestMock).toHaveBeenCalledWith(
-            "payment-methods?page=1&limit=10",
+            "/v2/payment-methods?page=1&limit=10",
             { method: "GET" },
         );
         expect(response).toEqual(mockResponse);
@@ -101,7 +101,7 @@ describe("PaymentMethod API", () => {
 
         requestMock.mockResolvedValue(mockResponse);
         const response = await paymentMethodApi.create(payload);
-        expect(requestMock).toHaveBeenCalledWith("payment-method", {
+        expect(requestMock).toHaveBeenCalledWith("/v2/payment-method", {
             data: payload,
             method: "POST",
         });
@@ -136,7 +136,7 @@ describe("PaymentMethod API", () => {
         requestMock.mockResolvedValue(mockResponse);
         const response = await paymentMethodApi.retrieve(paymentMethodId);
         expect(requestMock).toHaveBeenCalledWith(
-            `payment-method/${paymentMethodId}`,
+            `/v2/payment-method/${paymentMethodId}`,
             { method: "GET" },
         );
         expect(response).toEqual(mockResponse);
@@ -152,7 +152,7 @@ describe("PaymentMethod API", () => {
         requestMock.mockResolvedValue(mockResponse);
         const response = await paymentMethodApi.delete(paymentMethodId);
         expect(requestMock).toHaveBeenCalledWith(
-            `payment-method/${paymentMethodId}`,
+            `/v2/payment-method/${paymentMethodId}`,
             { method: "DELETE" },
         );
         expect(response).toEqual(mockResponse);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@loop-crypto/loop-core-sdk",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Loop Core SDK",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/resources/paymentmethod/index.ts
+++ b/src/resources/paymentmethod/index.ts
@@ -13,16 +13,18 @@ export class PaymentMethod extends Base {
     ): Promise<PaymentMethodsResponse> {
         const queryString = queryParams
             ? `?${new URLSearchParams(
-                queryParams as Record<string, string>,
-            ).toString()}`
+                  queryParams as Record<string, string>,
+              ).toString()}`
             : "";
-        return this.request(`payment-methods${queryString}`, { method: "GET" });
+        return this.request(`/v2/payment-methods${queryString}`, {
+            method: "GET",
+        });
     }
 
     create(
         payload: CreatePaymentMethodRequest,
     ): Promise<PaymentMethodResponse> {
-        return this.request(`payment-method`, {
+        return this.request(`/v2/payment-method`, {
             data: payload,
             method: "POST",
         });
@@ -32,20 +34,20 @@ export class PaymentMethod extends Base {
         paymentMethodId: string,
         updateData: UpdatePaymentMethodRequest,
     ): Promise<PaymentMethodResponse> {
-        return this.request(`payment-method/${paymentMethodId}`, {
+        return this.request(`/v2/payment-method/${paymentMethodId}`, {
             method: "PATCH",
             data: updateData,
         });
     }
 
     retrieve(paymentMethodId: string): Promise<PaymentMethodResponse> {
-        return this.request(`payment-method/${paymentMethodId}`, {
+        return this.request(`/v2/payment-method/${paymentMethodId}`, {
             method: "GET",
         });
     }
 
     delete(paymentMethodId: string): Promise<PaymentMethodsResponse> {
-        return this.request(`payment-method/${paymentMethodId}`, {
+        return this.request(`/v2/payment-method/${paymentMethodId}`, {
             method: "DELETE",
         });
     }


### PR DESCRIPTION
# ✅ Tickets / References

- LC-3739

# 🌞 Tasks completed
<!-- Required tasks completed that the reviewer can "check" when confirmed -->

1. [ ] Updated payment methods endpoints to include the version

# 📑 Notes for reviewer
<!-- Anything worth noting for the reviewer (or for posterity) -->

- Was not constant with the other endpoints so any calls using payment methods didn't work when using the SDK 

